### PR TITLE
Add Test on Language API

### DIFF
--- a/back/src/test/java/org/crunchytorch/coddy/application/api/HelloTest.java
+++ b/back/src/test/java/org/crunchytorch/coddy/application/api/HelloTest.java
@@ -5,6 +5,7 @@ import org.crunchytorch.coddy.application.utils.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
@@ -12,11 +13,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
         , classes = Main.class)
 public class HelloTest {
 
-    private TestRestTemplate restTemplate = new TestRestTemplate();
+    @Autowired
+    private TestRestTemplate restTemplate;
 
     @Test
     public void health() {

--- a/back/src/test/java/org/crunchytorch/coddy/application/utils/TestUtils.java
+++ b/back/src/test/java/org/crunchytorch/coddy/application/utils/TestUtils.java
@@ -7,10 +7,6 @@ import java.io.InputStream;
 
 public class TestUtils {
 
-    private static final String SERVER_HOST = "localhost";
-
-    private static final int SERVER_PORT = 8888;
-
     private static final String API_PREFIX = "/api/v1";
 
     private TestUtils() {
@@ -22,7 +18,7 @@ public class TestUtils {
      * @return the built url with the given endpoint
      */
     public static String getUrl(final String endpoint) {
-        return "http://" + SERVER_HOST + ":" + SERVER_PORT + API_PREFIX + endpoint;
+        return API_PREFIX + endpoint;
     }
 
     /**

--- a/back/src/test/java/org/crunchytorch/coddy/application/utils/TestUtils.java
+++ b/back/src/test/java/org/crunchytorch/coddy/application/utils/TestUtils.java
@@ -34,7 +34,7 @@ public class TestUtils {
      * @return an object instance by the data contains inside the json file
      * @throws IOException if the file doesn't exist
      */
-    public static <T> T getObjecFromJson(final String jsonFile, Class<T> object) throws IOException {
+    public static <T> T getObjectFromJson(final String jsonFile, Class<T> object) throws IOException {
         InputStream stream = null;
         try {
             ObjectMapper mapper = new ObjectMapper();

--- a/back/src/test/java/org/crunchytorch/coddy/language/api/LanguageWithPropertiesTest.java
+++ b/back/src/test/java/org/crunchytorch/coddy/language/api/LanguageWithPropertiesTest.java
@@ -5,6 +5,7 @@ import org.crunchytorch.coddy.application.utils.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
@@ -13,14 +14,15 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = Main.class)
 @TestPropertySource(locations = "classpath:language/application.properties")
 public class LanguageWithPropertiesTest {
 
     private static final String LANGUAGE_ENDPOINT = "/language";
 
-    private TestRestTemplate restTemplate = new TestRestTemplate();
+    @Autowired
+    private TestRestTemplate restTemplate;
 
     @Test
     public void getLanguagesTest() {

--- a/back/src/test/java/org/crunchytorch/coddy/language/api/LanguageWithPropertiesTest.java
+++ b/back/src/test/java/org/crunchytorch/coddy/language/api/LanguageWithPropertiesTest.java
@@ -1,0 +1,33 @@
+package org.crunchytorch.coddy.language.api;
+
+import org.crunchytorch.coddy.Main;
+import org.crunchytorch.coddy.application.utils.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+        classes = Main.class)
+@TestPropertySource(locations = "classpath:language/application.properties")
+public class LanguageWithPropertiesTest {
+
+    private static final String LANGUAGE_ENDPOINT = "/language";
+
+    private TestRestTemplate restTemplate = new TestRestTemplate();
+
+    @Test
+    public void getLanguagesTest() {
+        ResponseEntity<String[]> response = this.restTemplate.getForEntity(TestUtils.getUrl(LANGUAGE_ENDPOINT), String[].class);
+        String[] expected = new String[]{"1c", "abnf", "accesslog", "actionscript", "ada", "apache", "applescript", "arduino", "armasm", "asciidoc"};
+
+        Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assert.assertArrayEquals(expected, response.getBody());
+    }
+}

--- a/back/src/test/java/org/crunchytorch/coddy/language/api/LanguageWithoutPropertiesTest.java
+++ b/back/src/test/java/org/crunchytorch/coddy/language/api/LanguageWithoutPropertiesTest.java
@@ -5,6 +5,7 @@ import org.crunchytorch.coddy.application.utils.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
@@ -12,18 +13,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = Main.class)
 public class LanguageWithoutPropertiesTest {
 
     private static final String LANGUAGE_ENDPOINT = "/language";
 
-    private TestRestTemplate restTemplate = new TestRestTemplate();
+    @Autowired
+    private TestRestTemplate restTemplate;
 
     @Test
     public void getLanguagesTest() {
         ResponseEntity<String[]> response = this.restTemplate.getForEntity(TestUtils.getUrl(LANGUAGE_ENDPOINT), String[].class);
-        String[] expected = new String[]{"java", "cpp", "python","go"};
+        String[] expected = new String[]{"java", "cpp", "python", "go"};
 
         Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
         Assert.assertArrayEquals(expected, response.getBody());

--- a/back/src/test/java/org/crunchytorch/coddy/language/api/LanguageWithoutPropertiesTest.java
+++ b/back/src/test/java/org/crunchytorch/coddy/language/api/LanguageWithoutPropertiesTest.java
@@ -1,0 +1,31 @@
+package org.crunchytorch.coddy.language.api;
+
+import org.crunchytorch.coddy.Main;
+import org.crunchytorch.coddy.application.utils.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+        classes = Main.class)
+public class LanguageWithoutPropertiesTest {
+
+    private static final String LANGUAGE_ENDPOINT = "/language";
+
+    private TestRestTemplate restTemplate = new TestRestTemplate();
+
+    @Test
+    public void getLanguagesTest() {
+        ResponseEntity<String[]> response = this.restTemplate.getForEntity(TestUtils.getUrl(LANGUAGE_ENDPOINT), String[].class);
+        String[] expected = new String[]{"java", "cpp", "python","go"};
+
+        Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assert.assertArrayEquals(expected, response.getBody());
+    }
+}

--- a/back/src/test/java/org/crunchytorch/coddy/user/api/UserTest.java
+++ b/back/src/test/java/org/crunchytorch/coddy/user/api/UserTest.java
@@ -27,13 +27,14 @@ import java.io.IOException;
 import java.util.Arrays;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = Main.class)
 public class UserTest {
 
     private static final String USER_ENDPOINT = "/user";
 
-    private TestRestTemplate restTemplate = new TestRestTemplate();
+    @Autowired
+    private TestRestTemplate restTemplate;
 
     @Autowired
     private UserRepository repository;

--- a/back/src/test/java/org/crunchytorch/coddy/user/api/UserTest.java
+++ b/back/src/test/java/org/crunchytorch/coddy/user/api/UserTest.java
@@ -40,7 +40,7 @@ public class UserTest {
 
     @Before
     public void populateDataBase() throws IOException {
-        UserEntity[] users = TestUtils.getObjecFromJson("user/user.database.json", UserEntity[].class);
+        UserEntity[] users = TestUtils.getObjectFromJson("user/user.database.json", UserEntity[].class);
 
         repository.save(Arrays.asList(users));
     }
@@ -68,7 +68,7 @@ public class UserTest {
         ResponseEntity<SimpleUser> response = restTemplate.exchange(TestUtils.getUrl(USER_ENDPOINT + "/ciceron"), HttpMethod.GET, entity, SimpleUser.class);
 
         Assert.assertEquals(HttpStatus.OK, response.getStatusCode());
-        MatcherAssert.assertThat(response.getBody(), Matchers.sameBeanAs(TestUtils.getObjecFromJson("user/getUserWithTokenExpected.json", SimpleUser.class)));
+        MatcherAssert.assertThat(response.getBody(), Matchers.sameBeanAs(TestUtils.getObjectFromJson("user/getUserWithTokenExpected.json", SimpleUser.class)));
     }
 
     @Test

--- a/back/src/test/resources/application.properties
+++ b/back/src/test/resources/application.properties
@@ -1,7 +1,11 @@
+## This root properties will affect all test. So if you want some specific value for your specific test, please use @TestPropertySource
+## to inject your properties for just your test
+
 #if the below properties is not setted, then spring boot will start an embedded database elasticsearch which is perfect for the test
 #spring.data.elasticsearch.cluster-nodes=localhost:9200
 spring.data.elasticsearch.properties.path.data=build/elasticsearch-data/
 server.port=8888
-# coddy configuration
+
+# coddy global configuration
 org.crunchytorch.coddy.jwt.secret=secret
 logging.level.org.crunchytorch=DEBUG

--- a/back/src/test/resources/application.properties
+++ b/back/src/test/resources/application.properties
@@ -4,7 +4,6 @@
 #if the below properties is not setted, then spring boot will start an embedded database elasticsearch which is perfect for the test
 #spring.data.elasticsearch.cluster-nodes=localhost:9200
 spring.data.elasticsearch.properties.path.data=build/elasticsearch-data/
-server.port=8888
 
 # coddy global configuration
 org.crunchytorch.coddy.jwt.secret=secret

--- a/back/src/test/resources/language/application.properties
+++ b/back/src/test/resources/language/application.properties
@@ -1,0 +1,1 @@
+org.crunchytorch.coddy.languages=1c,abnf,accesslog,actionscript,ada,apache,applescript,arduino,armasm,asciidoc


### PR DESCRIPTION
* Use specific `application.properties` when we test the language api.
* inject `RestTemplateTest` instead of created it
* use random port in order to run multiple integration test without port conflict
* use relative path to make http request instead of absolute path

:warning: This PL must be merged after #32 